### PR TITLE
Fix duplicate function definition

### DIFF
--- a/jupyter-launcher/main.py
+++ b/jupyter-launcher/main.py
@@ -31,9 +31,6 @@ def save_config(config: Dict) -> None:
     except IOError as e:
         sg.popup_error(f"Error saving configuration file: {e}")
 
-def get_pinned_folder_labels(config):
-    """Return a list of pinned folder labels for the pinned combo box."""
-    return [item["label"] for item in config["pinned_folders"]]
 
 
 def get_pinned_folder_labels(config: Dict) -> List[str]:


### PR DESCRIPTION
## Summary
- remove duplicate function `get_pinned_folder_labels`
- only keep typed version

## Testing
- `flake8 jupyter-launcher/main.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7e37a1dc832aadbd12ffd0e92793